### PR TITLE
Fixing type error with loop function in processProcessing

### DIFF
--- a/snap/s4a/morphic.js
+++ b/snap/s4a/morphic.js
@@ -122,7 +122,7 @@ WorldMorph.prototype.Arduino.processProcessing = function (body) {
     body = body.replace('stopped', 1500);
     body = body.replace('counter-clockwise', 1700);
 
-    if (body.indexOf('void loop()' < 0)) {
+    if (body.indexOf('void loop()') < 0) {
         setup += body.replace(/\n/g, '\n  ') + '\n';
         body = '\n\nvoid loop() {}\n';
     } 


### PR DESCRIPTION
There is a problem in the generation for Arduino sketches (_processProcessing_ function). It creates two _loop_ functions: the first into the _setup_ function, and another empty function in the end of the sketch.

It's only a _typo_ error:
`if (body.indexOf('void loop()' < 0))`
must be
`if (body.indexOf('void loop()') < 0)`

Thanks!

Joan
