### PR TITLE
Portuguese translation of PWM block improved

### DIFF
--- a/snap/s4a/s4a-lang-pt.js
+++ b/snap/s4a/s4a-lang-pt.js
@@ -112,7 +112,7 @@ s4aTempDict = {
         'coloca o servo %servoPin %servoValue',
 
     'set analog pin %pwmPin to %n':
-        'coloca no pino analógico %pwmPin o valor %n',
+        'coloca no pino «analógico» (PWM) %pwmPin o valor %n',
 
     'Connecting board at port\n': 
         'Ligando placa no porto\n',


### PR DESCRIPTION
The previous translation suggested the pins were analog. Now it is clear they are not really analog. 
