### PR TITLE
Updating catalan translation and pwm block title

### DIFF
--- a/snap/s4a/objects.js
+++ b/snap/s4a/objects.js
@@ -75,7 +75,8 @@ SpriteMorph.prototype.initArduinoBlocks = function () {
         only: SpriteMorph,
         type: 'command',
         category: 'arduino',
-        spec: 'set analog pin %pwmPin to %n',
+        spec: 'set pin %pwmPin to %n value',
+	defaults: [128],
         translatable: true
     };
 

--- a/snap/s4a/s4a-lang-.js
+++ b/snap/s4a/s4a-lang-.js
@@ -109,7 +109,7 @@ s4aTempDict = {
     'set servo %servoPin to %servoValue':
         '',
 
-    'set analog pin %pwmPin to %n':
+    'set pin %pwmPin to %n value':
         '',
 
     'Connecting board at port\n': 

--- a/snap/s4a/s4a-lang-ca.js
+++ b/snap/s4a/s4a-lang-ca.js
@@ -79,16 +79,16 @@ s4aTempDict = {
         'angle (0-180)',
 
     'connect to Arduino':
-        'connectar a Arduino',
+        'connecta a Arduino',
 
     'disconnect Arduino':
-        'desconnectar Arduino',
+        'desconnecta Arduino',
 
     'Connect Arduino':
-        'Connectar Arduino',
+        'Connecta Arduino',
 
     'Disconnect Arduino':
-        'Desconnectar Arduino',
+        'Desconnecta Arduino',
 
     'analog reading %analogPin':
         'lectura analògica %analogPin',
@@ -100,16 +100,16 @@ s4aTempDict = {
         "connecta l'Arduino al port %s",
 
     'setup digital pin %digitalPin as %pinMode':
-        'configurar pin %digitalPin com a %pinMode',
+        'configura pin %digitalPin com a %pinMode',
 
     'set digital pin %digitalPin to %b':
-        'posar pin digital %digitalPin a %b',
+        'posa el pin digital %digitalPin a %b',
 
     'set servo %servoPin to %servoValue':
-        'posar servo %servoPin a %servoValue',
+        'posar el servo %servoPin a %servoValue',
 
-    'set analog pin %pwmPin to %n':
-        'posar pin analògic %pwmPin a %n',
+    'set pin %pwmPin to %n value':
+        'posar el pin analògic %pwmPin al valor %n',
 
     'Connecting board at port\n': 
         'Connectant placa al port\n',

--- a/snap/s4a/s4a-lang-cs.js
+++ b/snap/s4a/s4a-lang-cs.js
@@ -104,7 +104,7 @@ s4aTempDict = {
     'set servo %servoPin to %servoValue':
         'nastav servo %servoPin na %servoValue',
 
-    'set analog pin %pwmPin to %n':
+    'set pin %pwmPin to %n value':
         'nastav PWM pin %pwmPin na %n',
 
     'Connecting board at port\n': 

--- a/snap/s4a/s4a-lang-de.js
+++ b/snap/s4a/s4a-lang-de.js
@@ -104,8 +104,8 @@ s4aTempDict = {
     'set servo %servoPin to %servoValue':
         'Setze Servo %servoPin auf %servoValue',
 
-    'set analog pin %pwmPin to %n':
-        'Setze analogen Pin %pwmPin auf %n',
+    'set pin %pwmPin to %n value':
+        'Setze Pin %pwmPin auf %n',
 
     'Connecting board at port\n': 
         'Verbinde mit Board an Port\n',

--- a/snap/s4a/s4a-lang-es.js
+++ b/snap/s4a/s4a-lang-es.js
@@ -104,8 +104,8 @@ s4aTempDict = {
     'set servo %servoPin to %servoValue':
         'fijar servo %servoPin en %servoValue',
 
-    'set analog pin %pwmPin to %n':
-        'fijar pin analógico %pwmPin en %n',
+    'sset pin %pwmPin to %n value':
+        'fijar pin %pwmPin al valor %n',
 
     'Connecting board at port\n': 
         'Conectando tarjeta en la puerta\n',

--- a/snap/s4a/s4a-lang-et.js
+++ b/snap/s4a/s4a-lang-et.js
@@ -109,8 +109,8 @@ s4aTempDict = {
     'set servo %servoPin to %servoValue':
         'määra servoviigule %servoPin väärtus %servoValue',
 
-    'set analog pin %pwmPin to %n':
-        'määra analoogviigule %pwmPin väärtus %n',
+    'set pin %pwmPin to %n value':
+        'määra viigule %pwmPin väärtus %n',
 
     'Connecting board at port\n': 
         'Ühenduse loomine plaadiga pordis\n',

--- a/snap/s4a/s4a-lang-he.js
+++ b/snap/s4a/s4a-lang-he.js
@@ -67,7 +67,7 @@
     
     'set digital pin %digitalPin to %b':  '%b -ל %digitalPin דיגיטליית רגל שנה',
     'set servo %servoPin to %servoValue': '%servoValue -ל %servoPin ברגל מנוע הבא',
-    'set analog pin %pwmPin to %n': '%n -ל %pwmPin ברגל PWM קבע',
+    'sset pin %pwmPin to %n value': '%n -ל %pwmPin ברגל PWM קבע',
     'Connecting board at port\n':  'חבר לכניסה\n',
     'An Arduino board has been connected. Happy prototyping!': 'ארדוינו חובר  בהצלחה!',
     

--- a/snap/s4a/s4a-lang-it.js
+++ b/snap/s4a/s4a-lang-it.js
@@ -107,8 +107,8 @@ s4aTempDict = {
     'set servo %servoPin to %servoValue':
         'imposta servo %servoPin a %servoValue',
 
-    'set analog pin %pwmPin to %n':
-        'imposta il pin analogico %pwmPin a %n',
+    'set pin %pwmPin to %n value':
+        'imposta il pin %pwmPin a %n',
 
     'Connecting board at port\n': 
         'Sto collegando la scheda alla porta\n',

--- a/snap/s4a/s4a-lang-nl.js
+++ b/snap/s4a/s4a-lang-nl.js
@@ -104,8 +104,8 @@ s4aTempDict = {
     'set servo %servoPin to %servoValue':
         'zet servo %servoPin op %servoValue',
 
-    'set analog pin %pwmPin to %n':
-        'zet analoge pin %pwmPin op %n',
+    'set pin %pwmPin to %n value':
+        'zet pin %pwmPin op %n',
 
     'Connecting board at port\n': 
         'Verbinding maken op poort\n',

--- a/snap/s4a/s4a-lang-pt.js
+++ b/snap/s4a/s4a-lang-pt.js
@@ -108,8 +108,8 @@ s4aTempDict = {
     'set servo %servoPin to %servoValue':
         'coloca o servo %servoPin %servoValue',
 
-    'set analog pin %pwmPin to %n':
-        'coloca no pino «analógico» (PWM) %pwmPin o valor %n',
+    'set pin %pwmPin to %n value':
+        'coloca no pino (PWM) %pwmPin o valor %n',
 
     'Connecting board at port\n': 
         'Ligando placa no porto\n',

--- a/snap/s4a/s4a-lang-pt_BR.js
+++ b/snap/s4a/s4a-lang-pt_BR.js
@@ -122,8 +122,8 @@ s4aTempDict = {
     'set servo %servoPin to %servoValue':
         'posicione o servo %servoPin em %servoValue',
 
-    'set analog pin %pwmPin to %n':
-        'coloque no pino analógico %pwmPin o valor %n',
+    'set pin %pwmPin to %n value':
+        'coloque no pino %pwmPin o valor %n',
 
     'Connecting board at port\n': 
         'Conectando o Arduino na porta\n',

--- a/snap/s4a/s4a-lang-ru.js
+++ b/snap/s4a/s4a-lang-ru.js
@@ -97,7 +97,7 @@ s4aTempDict = {
     'set servo %servoPin to %servoValue':
         'изменить статус разъема серво %servoPin нa %servoValue',
 
-    'set analog pin %pwmPin to %n':
+    'set pin %pwmPin to %n value':
         'изменить статус разъема PWM %pwmPin на %n',
 
     'Connecting board at port\n': 

--- a/snap/s4a/s4a-lang-uk.js
+++ b/snap/s4a/s4a-lang-uk.js
@@ -97,7 +97,7 @@ s4aTempDict = {
     'set servo %servoPin to %servoValue':
         'змінити статус роз\u2019єму серво %servoPin нa %servoValue',
 
-    'set analog pin %pwmPin to %n':
+    'set pin %pwmPin to %n value':
         'змінити статус роз\u2019єму PWM %pwmPin на %n',
 
     'Connecting board at port\n': 

--- a/snap/s4a/s4a-lang-zh.js
+++ b/snap/s4a/s4a-lang-zh.js
@@ -65,7 +65,7 @@ s4aTempDict = {
     'set servo %servoPin to %servoValue':
         '设置伺服针脚 %servoPin 为 %servoValue',
 
-    'set analog pin %pwmPin to %n':
+    'set pin %pwmPin to %n value':
         '设置PWM %pwmPin 为 %n',
 
     'Connecting board at port\n': 


### PR DESCRIPTION
This PR updates catalan translation for S4A blocks and changes _PWM_ block title.
Now, we have _set pin %pwmPin to %n value_ and we have a default 128 value (showing value is not 0/1). We have deleted _analog_ word, because we are working with digital (pwm) pins.
