### PR TITLE
Adding JS functionality to web/chromeos

### DIFF
--- a/src/platforms/web/chromeos/root/chromeos/threads.js
+++ b/src/platforms/web/chromeos/root/chromeos/threads.js
@@ -1,0 +1,13 @@
+Process.prototype.reportJSFunction = function (parmNames, body) {
+	return document.getElementById("sandboxFrame").contentWindow.reportJSFunction(this, parmNames, body);
+};
+Process.prototype.originalEvaluate = Process.prototype.evaluate;
+Process.prototype.evaluate = function (context, args, isCommand) {
+	if (typeof context == 'function') {
+		return context.apply(
+            this.blockReceiver(),
+            args.asArray().concat([this])
+		);
+	}
+	this.originalEvaluate(context, args, isCommand);
+};

--- a/src/platforms/web/chromeos/root/chromeos/threads.js
+++ b/src/platforms/web/chromeos/root/chromeos/threads.js
@@ -3,7 +3,11 @@ Process.prototype.reportJSFunction = function (parmNames, body) {
 		return document.getElementById("sandboxFrame").contentWindow.reportJSFunction(this, parmNames, body);
 	}
 	catch(error) {
-		throw new Error("To run JS in this ChomeOS app, you must launch Chrome/Chromium with this parameters: --disable-web-security --user-data-dir");
+		if (error.toString().indexOf("from accessing a cross-origin") != -1) {
+			throw new Error("To run JS in this ChomeOS app, you must launch Chrome/Chromium with this parameters: --disable-web-security --user-data-dir");
+		} else {
+			throw new Error(error);
+		}
 	}
 	
 };

--- a/src/platforms/web/chromeos/root/chromeos/threads.js
+++ b/src/platforms/web/chromeos/root/chromeos/threads.js
@@ -1,5 +1,11 @@
 Process.prototype.reportJSFunction = function (parmNames, body) {
-	return document.getElementById("sandboxFrame").contentWindow.reportJSFunction(this, parmNames, body);
+	try {
+		return document.getElementById("sandboxFrame").contentWindow.reportJSFunction(this, parmNames, body);
+	}
+	catch(error) {
+		throw new Error("To run JS in this ChomeOS app, you must launch Chrome/Chromium with this parameters: --disable-web-security --user-data-dir");
+	}
+	
 };
 Process.prototype.originalEvaluate = Process.prototype.evaluate;
 Process.prototype.evaluate = function (context, args, isCommand) {

--- a/src/platforms/web/chromeos/root/index.html
+++ b/src/platforms/web/chromeos/root/index.html
@@ -17,6 +17,7 @@
         
         <script type="text/javascript" src="threads.js"></script>
         <script type="text/javascript" src="s4a/threads.js"></script>
+		<script type="text/javascript" src="chromeos/threads.js"></script>
 
         <script type="text/javascript" src="objects.js"></script>
         <script type="text/javascript" src="s4a/objects.js"></script>
@@ -49,5 +50,6 @@
         </head>
         <body style="margin: 0;">
             <canvas id="world" tabindex="1" style="position: absolute;" />
+			<iframe id="sandboxFrame" src="sandbox.html" style="display: none;"></iframe>
         </body>
     </html>

--- a/src/platforms/web/chromeos/root/manifest.json
+++ b/src/platforms/web/chromeos/root/manifest.json
@@ -17,5 +17,8 @@
         },
         "storage"
     ],  
-    "icons": { "16": "icon-16.png", "128": "icon-128.png" }
+    "icons": { "16": "icon-16.png", "128": "icon-128.png" },
+	"sandbox": {
+        "pages": ["sandbox.html"]
+	}
 }

--- a/src/platforms/web/chromeos/root/sandbox.html
+++ b/src/platforms/web/chromeos/root/sandbox.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+    <head>
+		<title>Sandbox page from Snap4Arduino ChromeOS app</title>
+    <script type="text/javascript">
+    	function reportJSFunction(context, parmNames, body) {
+			return Function.apply(
+		        context,
+		        parmNames.asArray().concat([body])
+			    );
+		};
+    </script>
+    </head>
+    <body>
+    </body>
+</html>

--- a/src/platforms/web/chromium/build
+++ b/src/platforms/web/chromium/build
@@ -19,7 +19,7 @@ echo "Fetching more platform-specific files"
 echo "======="
 echo
 
-cp -r src/platforms/web/chromium/crx tmp
+cp -rL src/platforms/web/chromium/crx tmp
 
 echo
 echo "======="


### PR DESCRIPTION
-Fixing a problem in web/chromium builder
-Adding JS functionality to web/chromeos
- To use JS block, we must launch chrome/chromium with 'cross-origin' policies disabled
- This is 'google-chrome --disable-web-security --user-data-dir'

TODO
- [x] Document chrome launcher
- [x] New error message ("cross-origin" error) with launcher info.
- [ ] Implement more firmata functions to web/chromeos and chromium
