### PR TITLE
Fixing disconnect error in chromeos. Avoid error calling removeAllLis…

### DIFF
--- a/src/platforms/web/firmata.js
+++ b/src/platforms/web/firmata.js
@@ -388,6 +388,8 @@ var Board = function(port, callback) {
 
         this.transport = this.sp;
 
+		this.sp.removeAllListeners = nop;
+
         this.sp.on('error', function(string) {
             callback(string);
         });


### PR DESCRIPTION
…teners in chromeos

Disconnect button in chromeos is not working ok. It disconnects the board but is not finish properly and then, reconnect is not available.

This PR fix the problem redefining removeAllListeners (nodejs function). Chromium version is already working because there is the redefinition in populateBoard.
