### PR TITLE
Fixing transient option  missing in reportGetVar block (#102)

### DIFF
--- a/src/s4a/blocks.js
+++ b/src/s4a/blocks.js
@@ -137,6 +137,16 @@ BlockMorph.prototype.userMenu = function () {
         top,
         blck;
 
+	function addOption(label, toggle, test, onHint, offHint) {
+        var on = '\u2611 ',
+            off = '\u2610 ';
+        menu.addItem(
+            (test ? on : off) + localize(label),
+            toggle,
+            test ? onHint : offHint
+        );
+    }
+
     menu.addItem(
         "help...",
         'showHelp'


### PR DESCRIPTION
Fixing #102 
Maybe is better remaking definitions using 
```
BlockMorph.prototype.originalUserMenu = BlockMorph.prototype.userMenu;
BlockMorph.prototype.userMenu = function(spec) {...
```
but this, fix detected issue.

Joan