### PR TITLE
Fixing version checking

### DIFF
--- a/src/platforms/desktop/root/desktop/gui.js
+++ b/src/platforms/desktop/root/desktop/gui.js
@@ -9,7 +9,7 @@ IDE_Morph.prototype.checkForNewVersion = function () {
         latest = this.getURL('http://snap4arduino.org/downloads/LATEST'),
         current = this.version();
     
-    if (current !== latest) {
+    if (current < latest) {
         this.confirm(
             'A new version of Snap4Arduino has been released: ' 
                 + latest 


### PR DESCRIPTION
Hi Bernat!
New checkForNewVersion feature checks (current !== latest).
Then, development versions are asked for downloading the "newer" version.
I suggest (current < latest). I am not thinking only in developers. Future RC versions will be publicated, and this is a noise for our future testers that we can avoid them.
Thanks!
Joan