### PR TITLE
Make build works on BSD system

### DIFF
--- a/build
+++ b/build
@@ -101,19 +101,19 @@ build() {
         rm -rf tmp
 
         echo "Fetching Snap! sources..."
-        if ! cp -r src/snap tmp; then
+        if ! cp -R src/snap tmp; then
             print_error "Could not find Snap! sources.\nPlease run prepare --snap first."
             exit 1
         fi
         
         echo "Fetching Snap4Arduino core..."
-        if ! cp -r src/s4a tmp; then
+        if ! cp -R src/s4a tmp; then
             print_error "Could not find Snap4Arduino core. Please make sure a src/s4a exists and contains the Snap4Arduino core files."
             exit 1
         fi
         
         echo "Fetching platform-specific sources..."
-        if ! cp -r -L src/platforms/$each/root/* tmp; then
+        if ! cp -R -L src/platforms/$each/root/* tmp; then
             print_warning "Could not find any platform-specific files for $each."
         fi
         
@@ -189,14 +189,14 @@ pack() {
         elif echo "$each" | grep gnu; then
             filename=$name.tar.gz
             mkdir ../$name
-            cp -r * ../$name
+            cp -R * ../$name
             mv ../$name .
             tar -czf $filename $name
             rm -rf $name
         else
             filename=$name.zip
             mkdir ../$name
-            cp -r * ../$name
+            cp -R * ../$name
             mv ../$name .
             zip -r $filename $name
             rm -rf $name

--- a/build
+++ b/build
@@ -40,7 +40,7 @@ print_help_platforms() {
     echo "Usage: ./build --platform=TARGET [--run] [--deploy=URL --username=USERNAME [--dir=PATH]]"
     echo
     echo "Available platforms are:"
-    echo "`find src/platforms -follow -name '*.buildme*' | sed -r 's|/[^/]+$||' | cut -c 15-`"
+    echo "`find src/platforms -follow -name '*.buildme*' | sed -E 's|/[^/]+$||' | cut -c 15-`"
     echo
     echo "Generic names are also accepted, such as:"
     echo "desktop"
@@ -66,7 +66,7 @@ if test -n "$help"; then
     fi
 fi
 
-allplatforms=`find src/platforms -follow -name '*.buildme*' | sed -r 's|/[^/]+$||' | cut -c 15-`
+allplatforms=`find src/platforms -follow -name '*.buildme*' | sed -E 's|/[^/]+$||' | cut -c 15-`
 
 if test -n "$platform"; then
     
@@ -182,7 +182,7 @@ pack() {
     for each in $platforms; do
         echo "Packing $each version"
         cd releases/$each
-        name='Snap4Arduino_'`echo "$each" | sed -r "s/\//-/g"`"_$version"
+        name='Snap4Arduino_'`echo "$each" | sed -E "s/\//-/g"`"_$version"
         if echo "$each" | grep win && test -n "$makeinstaller"; then
             filename=$name.zip
             zip $filename Snap4Arduino-$version*.exe

--- a/src/platforms/desktop/build
+++ b/src/platforms/desktop/build
@@ -13,7 +13,7 @@ echo "Setting up Node dependencies..."
 echo "======="
 echo
 
-cp -rv environments/desktop/node_modules tmp
+cp -Rv environments/desktop/node_modules tmp
 
 echo
 echo "======="
@@ -73,7 +73,7 @@ elif echo $1 | grep gnu; then
     echo "Copying icon files over..."
     echo "======="
     echo
-    cp -r assets/icons releases/$1
+    cp -R assets/icons releases/$1
     echo
     echo "======="
     echo "Copying desktop entry over..."

--- a/src/platforms/desktop/build
+++ b/src/platforms/desktop/build
@@ -21,7 +21,7 @@ echo "Setting version name..."
 echo "======="
 echo
 
-sed -r 's/.*version.*/  "version": "'`cat src\/version`'",/' src/platforms/desktop/root/package.json > tmp/package.json
+sed -E 's/.*version.*/  "version": "'`cat src\/version`'",/' src/platforms/desktop/root/package.json > tmp/package.json
 
 echo
 echo "======="

--- a/src/platforms/desktop/win/makeinstaller
+++ b/src/platforms/desktop/win/makeinstaller
@@ -3,7 +3,7 @@
 unset DISPLAY  
 
 # set the version and platform architecture in the corresponding template fields in the Inno Setup file
-cat src/platforms/desktop/win/Snap4Arduino.iss | sed -r 's/@AppVersion/'`cat src\/version`'/' | sed -r 's/@Architecture/'`echo $1 | tail -c 3`'/' > releases/$1/Snap4Arduino.iss
+cat src/platforms/desktop/win/Snap4Arduino.iss | sed -E 's/@AppVersion/'`cat src\/version`'/' | sed -E 's/@Architecture/'`echo $1 | tail -c 3`'/' > releases/$1/Snap4Arduino.iss
 
 cp assets/s4a.ico releases/$1
 cd releases/$1

--- a/src/platforms/embedded/cli/build
+++ b/src/platforms/embedded/cli/build
@@ -18,7 +18,7 @@ echo "Setting up Node dependencies..."
 echo "======="
 echo
 
-cp -rv environments/embedded/cli/node_modules tmp
+cp -Rv environments/embedded/cli/node_modules tmp
 
 echo
 echo "======="
@@ -36,4 +36,4 @@ echo
 
 rm -rf releases/embedded/cli
 mkdir -p releases/embedded
-cp -r tmp releases/embedded/cli
+cp -R tmp releases/embedded/cli

--- a/src/platforms/embedded/cli/super_root/install.sh
+++ b/src/platforms/embedded/cli/super_root/install.sh
@@ -14,7 +14,7 @@ echo "Installing Snap! interpreter at /usr/share/snap-interpreter"
 
 rm -Rf /usr/share/snap-interpreter
 mkdir /usr/share/snap-interpreter
-cp -r * /usr/share/snap-interpreter
+cp -R * /usr/share/snap-interpreter
 
 echo "Creating snap.js symlink"
 

--- a/src/platforms/embedded/ipkg/build
+++ b/src/platforms/embedded/ipkg/build
@@ -33,7 +33,7 @@ mkdir -p $OUTDIR/data/etc/init.d
 rm -r $SRCDIR/node_modules
 
 # Create data directory tree structure
-cp -r $SRCDIR/* $OUTDIR/data/usr/share/snap4arduino/.
+cp -R $SRCDIR/* $OUTDIR/data/usr/share/snap4arduino/.
 
 # Create control file and set version name
 sed -E 's/^Version.*/Version: v'`cat src\/version`'/' $PWD/src/templates/ipkg-control > $OUTDIR/ipkg/control
@@ -43,7 +43,7 @@ cp $PWD/src/templates/post* $OUTDIR/ipkg/
 cp $PWD/src/templates/prerm $OUTDIR/ipkg/
 
 # Generic build script arrives late to the party, we need to do the copying ourselves here
-cp -r $PWD/root/* $OUTDIR/data/usr/share/snap4arduino/.
+cp -R $PWD/root/* $OUTDIR/data/usr/share/snap4arduino/.
 
 # Add daemon script
 cp $PWD/src/templates/daemon.sh $OUTDIR/data/etc/init.d/snap4arduino-daemon

--- a/src/platforms/embedded/ipkg/build
+++ b/src/platforms/embedded/ipkg/build
@@ -36,7 +36,7 @@ rm -r $SRCDIR/node_modules
 cp -r $SRCDIR/* $OUTDIR/data/usr/share/snap4arduino/.
 
 # Create control file and set version name
-sed -r 's/^Version.*/Version: v'`cat src\/version`'/' $PWD/src/templates/ipkg-control > $OUTDIR/ipkg/control
+sed -E 's/^Version.*/Version: v'`cat src\/version`'/' $PWD/src/templates/ipkg-control > $OUTDIR/ipkg/control
 
 # Add custom scripts
 cp $PWD/src/templates/post* $OUTDIR/ipkg/

--- a/src/platforms/mobile/android/build
+++ b/src/platforms/mobile/android/build
@@ -31,7 +31,7 @@ echo "Setting version name..."
 echo "======="
 echo
 
-sed -r 's/^\s*version.*/  version="'`cat src\/version`'"/' src/platforms/mobile/android/config.xml > tmp/Snap4Arduino/config.xml
+sed -E 's/^\s*version.*/  version="'`cat src\/version`'"/' src/platforms/mobile/android/config.xml > tmp/Snap4Arduino/config.xml
 
 echo
 echo "======="

--- a/src/platforms/mobile/ios/build
+++ b/src/platforms/mobile/ios/build
@@ -30,7 +30,7 @@ echo "Setting version name..."
 echo "======="
 echo
 
-sed -r 's/^\s*version.*/  version="'`cat src\/version`'"/' src/platforms/mobile/ios/config.xml > tmp/Snap4Arduino/config.xml
+sed -E 's/^\s*version.*/  version="'`cat src\/version`'"/' src/platforms/mobile/ios/config.xml > tmp/Snap4Arduino/config.xml
 
 echo
 echo "======="

--- a/src/platforms/web/chromeos/build
+++ b/src/platforms/web/chromeos/build
@@ -18,7 +18,7 @@ echo "Setting version name"
 echo "======="
 echo
 
-sed -r 's/.*"version".*/  "version": "'`cat src\/version | sed -r "s/[a-z]|-//g" `'",/' src/platforms/web/chromeos/root/manifest.json | sed -r 's/.*version_name.*/  "version_name": "'`cat src\/version`'",/' > tmp/manifest.json
+sed -E 's/.*"version".*/  "version": "'`cat src\/version | sed -E "s/[a-z]|-//g" `'",/' src/platforms/web/chromeos/root/manifest.json | sed -E 's/.*version_name.*/  "version_name": "'`cat src\/version`'",/' > tmp/manifest.json
 
 echo
 echo "======="
@@ -26,7 +26,7 @@ echo "Changing all occurrences of localStorage for chrome.storage.local"
 echo "======="
 echo
 
-sed -i.bak -r 's/localStorage/chrome\.storage\.local/g' tmp/*.js 
+sed -i.bak -E 's/localStorage/chrome\.storage\.local/g' tmp/*.js
 rm tmp/*.bak
 
 echo

--- a/src/platforms/web/chromeos/build
+++ b/src/platforms/web/chromeos/build
@@ -10,7 +10,7 @@ echo "Setting up Node dependencies..."
 echo "======="
 echo
 
-cp -rv environments/web/chromeos/node_modules tmp
+cp -Rv environments/web/chromeos/node_modules tmp
 
 echo
 echo "======="

--- a/src/platforms/web/chromium/build
+++ b/src/platforms/web/chromium/build
@@ -27,7 +27,7 @@ echo "Setting version name..."
 echo "======="
 echo
 
-sed -r 's/.*"version".*/  "version": "'`cat src\/version`'",/' src/platforms/web/chromium/crx/manifest.json > tmp/crx/manifest.json
+sed -E 's/.*"version".*/  "version": "'`cat src\/version`'",/' src/platforms/web/chromium/crx/manifest.json > tmp/crx/manifest.json
 
 echo
 echo "======="

--- a/src/platforms/web/chromium/build
+++ b/src/platforms/web/chromium/build
@@ -19,7 +19,7 @@ echo "Fetching more platform-specific files"
 echo "======="
 echo
 
-cp -rL src/platforms/web/chromium/crx tmp
+cp -RL src/platforms/web/chromium/crx tmp
 
 echo
 echo "======="
@@ -35,7 +35,7 @@ echo "Setting up Node dependencies..."
 echo "======="
 echo
 
-cp -rv environments/web/chromium/node_modules tmp/crx
+cp -Rv environments/web/chromium/node_modules tmp/crx
 
 echo
 echo "======="


### PR DESCRIPTION
First, thanks for the amazing work on Snap4Arduino!

Building on BSD OS such as OS-X fails due to differences of behaviour in sed and cp command. Here are the modifications I add to make to build Snap4Arduino on my platform (OS-X 10.12.2). I tried to keep the changes compatible for linux, but I'm not a OS expert so I could have missed things here 😄 

I add to change:

* _sed -r_ with _sed -E_ (it seems to also works on linux platforms even if it's not documented)
* _cp -r_ with _cp -R_ (the old version -r fails when used in combination with -L on BSD)

Everything seems to work ok on my side now. Yet, I only tested the build for desktop/os/64. 

Let me know if there is other tests I can do.