### PR TITLE
Fixing #144 launcher with load param in snap translations

### DIFF
--- a/src/platforms/desktop/root/desktop/gui.js
+++ b/src/platforms/desktop/root/desktop/gui.js
@@ -1,4 +1,13 @@
-IDE_Morph.prototype.originalOpenIn = IDE_Morph.prototype.openIn;
+var originalCodeOpenIn = IDE_Morph.prototype.openIn.toString();
+var initFunction = originalCodeOpenIn.indexOf("\n") + 1;
+var changePoint = originalCodeOpenIn.indexOf("        } else if (location.hash.substr(0, 7) === '#signup') {\n" +
+    "            this.createCloudAccount();\n" +
+    "        }\n") + 112;
+var newCodeOpenIn = originalCodeOpenIn.slice(initFunction,changePoint) +
+    '        this.loadNewProject = false;\n' +
+    originalCodeOpenIn.slice(changePoint,-1);
+IDE_Morph.prototype.originalOpenIn = new Function(newCodeOpenIn);
+//IDE_Morph.prototype.originalOpenIn = IDE_Morph.prototype.openIn;
 IDE_Morph.prototype.openIn = function (world) {
     this.originalOpenIn(world);
     this.checkForNewVersion();
@@ -95,9 +104,17 @@ IDE_Morph.prototype.checkForCLIparams = function () {
                         'Error reading ' + fileName, 
                         'The file system reported:\n\n' + err);
                 } else {
-                    myself.droppedText(data);
+                    function checkInitFinished() {
+                        if(myself.loadNewProject) {
+                            window.setTimeout(checkInitFinished, 100); /* this checks the flag every 100 milliseconds*/
+                        } else {
+                            myself.droppedText(data);
+                        }
+                    }
+                    checkInitFinished();
                 }
             }
         );
     }
 };
+


### PR DESCRIPTION
This fix the problem reported in #144.
Two comments:
  - The changes in 'openIn' function are temporary, because these are reported to Snap! in this [PR](https://github.com/jmoenig/Snap--Build-Your-Own-Blocks/pull/1673). I guess it will be in next Snap release... and we'll have to drop it.
  - The changes in 'checkForCLIparams' are to load project after the translation reload (in a callback) ends. Maybe @bromagosa wants to improve this code.
Joan