### PR TITLE
Repairing repo2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/snap"]
 	path = src/snap
-	url = https://github.com/jmoenig/Snap--Build-Your-Own-Blocks
+	url = https://github.com/jguille2/Snap--Build-Your-Own-Blocks

--- a/prepare
+++ b/prepare
@@ -41,28 +41,6 @@ pull_snap() {
         print_error "Could not set up Snap! git submodule.\nPlease make sure that you have access to the Internet and git is installed in your system."
         exit 1
     fi
-    cd src/snap
-    git checkout master
-    if ! git pull; then
-        print_error "Could not pull latest Snap! version from Git.\nPlease make sure that you have access to the Internet and git is installed in your system."
-        cd ../..
-        exit 1
-    fi
-
-    echo "Fetching and pulling some unmerged pull requests"
-    git fetch origin refs/pull/1731/head
-    git fetch origin refs/pull/1676/head
-    git fetch origin refs/pull/1674/head
-    git fetch origin refs/pull/1673/head
-    git fetch origin refs/pull/1666/head
-    git fetch origin refs/pull/1663/head
-
-    git pull origin refs/pull/1731/head
-    git pull origin refs/pull/1676/head
-    git pull origin refs/pull/1674/head
-    git pull origin refs/pull/1673/head
-    git pull origin refs/pull/1666/head
-    git pull origin refs/pull/1663/head
 
     echo "Converting all sounds to a free format (OGG)"
     cd Sounds

--- a/src/platforms/web/chromium/crx/manifest.json
+++ b/src/platforms/web/chromium/crx/manifest.json
@@ -19,7 +19,8 @@
             "http://localhost:8080/*",
             "http://localhost/*",
             "http://snap4arduino.local/*",
-            "http://snap4arduino.org/*"
+            "http://snap4arduino.org/*",
+            "http://snap4arduino.rocks/*"
         ],
         "accepts_tls_channel_id": false
     },


### PR DESCRIPTION
Hi,
Second option to fix current broken repo (you must choose betwen #167 or this one).
This changes temporarily src/snap submodule pointer to jguille2:snap4arduino, including all the pending PRs. Then, prepare is changed, because all the changes are into the repo. Then, prepare does not change git local repo, and avoid new breaks.