### PR TITLE
Fixing bug in first readings

### DIFF
--- a/src/s4a/threads.js
+++ b/src/s4a/threads.js
@@ -136,22 +136,12 @@ Process.prototype.reportAnalogReading = function (pin) {
 
         if (board.pins[board.analogPins[pin]].mode != board.MODES.ANALOG) {
             board.pinMode(board.analogPins[pin], board.MODES.ANALOG);
-        }
-
-        // Ugly hack that fixes issue #5
-        // "say" block inside a "forever" loop shows only first reading on GNU/Linux and MS-Windows
-        // Until we find the source of the problem and a cleaner solution...
-
-        if (!this.context.justRead) {
-            this.context.justRead = true;
         } else {
-            this.context.justRead = false;
             return board.pins[board.analogPins[pin]].value;
         }
 
         this.pushContext('doYield');
         this.pushContext();
-
     } else {
         throw new Error(localize('Arduino not connected'));	
     }
@@ -161,13 +151,18 @@ Process.prototype.reportDigitalReading = function (pin) {
     var sprite = this.homeContext.receiver;
 
     if (sprite.arduino.isBoardReady()) {
+
         var board = sprite.arduino.board; 
 
         if (board.pins[pin].mode != board.MODES.INPUT) {
             board.pinMode(pin, board.MODES.INPUT);
-            board.digitalRead(pin, function(value) { board.pins[pin].value = value });
+            board.reportDigitalPin(pin, 1);
+        } else {
+            return board.pins[pin].value == 1;
         }
-        return board.pins[pin].value == 1;
+
+        this.pushContext('doYield');
+        this.pushContext();
     } else {
         throw new Error(localize('Arduino not connected'));		
     }


### PR DESCRIPTION
Hi,
We had problems with the first readings because the asynchronous procedures.
This PR fix these first digital readings, and also is applied to analogical readings (already fixed with an 'ugly' hack [in the past](https://github.com/edutec/Snap4Arduino-old-huge/commit/62fe25c611d17320ba9cd5edd95f7c0343226a90))

I know this fix must be also applied to the "others threads.js" (android, cli...) but I pull it to test and confirm the solution.