### PR TITLE
Broken repo2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/snap"]
 	path = src/snap
-	url = https://github.com/jmoenig/Snap--Build-Your-Own-Blocks
+	url = https://github.com/jguille2/Snap--Build-Your-Own-Blocks

--- a/prepare
+++ b/prepare
@@ -41,38 +41,6 @@ pull_snap() {
         print_error "Could not set up Snap! git submodule.\nPlease make sure that you have access to the Internet and git is installed in your system."
         exit 1
     fi
-    cd src/snap
-    git checkout master
-    if ! git pull; then
-        print_error "Could not pull latest Snap! version from Git.\nPlease make sure that you have access to the Internet and git is installed in your system."
-        cd ../..
-        exit 1
-    fi
-
-    echo "Fetching and pulling some unmerged pull requests"
-    git fetch origin refs/pull/1731/head
-    git fetch origin refs/pull/1676/head
-    git fetch origin refs/pull/1674/head
-    git fetch origin refs/pull/1673/head
-    git fetch origin refs/pull/1666/head
-    git fetch origin refs/pull/1663/head
-
-    git pull origin refs/pull/1731/head
-    git pull origin refs/pull/1676/head
-    git pull origin refs/pull/1674/head
-    git pull origin refs/pull/1673/head
-    git pull origin refs/pull/1666/head
-    git pull origin refs/pull/1663/head
-
-    echo "Converting all sounds to a free format (OGG)"
-    cd Sounds
-    for name in `ls *.mp3 | cut -f1 -d.`; do ffmpeg -i "$name.mp3" "$name.ogg"; done
-    rm *.mp3
-
-    sed -E 's/mp3/ogg/' catalog.json > catalog_ogg.json
-    mv catalog_ogg.json catalog.json
-
-    cd ../../..
 
     print_ok "Snap! sources up to date."
 }


### PR DESCRIPTION
Fixing current broken src/snap repo, pointing to jguille2:snap4arduino branch, to have current Snap with 6 pending PR and sound files converted to ogg. Also, prepare is updated, with a clean pull from this branch.