### PR TITLE
Fixing transpiler to define loop index variables as local vars

### DIFF
--- a/src/s4a/arduino.js
+++ b/src/s4a/arduino.js
@@ -498,7 +498,7 @@ Arduino.transpile = function (body, hatBlocks) {
     + 'byte detachedServoCount = 0;\n'
     + 'byte servoCount = 0;\n\n';
 
-    varLines = body.match(/int .* = 0;/g) || [];
+    varLines = body.match(/int .* = 0;\n/g) || [];
     body = body.replace(/int .* = 0;\n/g, '');
     varLines.forEach(function (each) {
         assignments += each + '\n';


### PR DESCRIPTION
Fixing #194 
Transpiler issue. With this change we avoid global definition for loop index variables, that has their own local definition.