### PR TITLE
Fixing #184 networkConnection issue

### DIFF
--- a/src/s4a/arduino.js
+++ b/src/s4a/arduino.js
@@ -187,7 +187,7 @@ Arduino.prototype.networkDialog = function () {
     var myself = this;
     new DialogBoxMorph(
             this, // target
-            function () { myself.connect(myself.hostname, false, 'network'); }, // action
+            function (hostName) { myself.connect(hostName, false, 'network'); }, // action
             this // environment
             ).prompt(
                 'Enter hostname or ip address:', // title


### PR DESCRIPTION
It fixes #184 problem.
Currently, network connection is always using the same _hostName:port_ (the default _arduino.local:23_ or other 'custom default' used in previous versions (before 1.2.3)) and we can not change it.