### PR TITLE
Closing connection and releasing serial after 'noFirmata' attempt

### DIFF
--- a/src/s4a/arduino.js
+++ b/src/s4a/arduino.js
@@ -33,15 +33,15 @@ Arduino.prototype.keepAlive = function () {
     }
 };
 
-Arduino.prototype.disconnect = function (silent) {
+Arduino.prototype.disconnect = function (silent, force) {
     // Prevent disconnection attempts before board is actually connected
-    if (this.board && this.isBoardReady()) {
+    if ((this.board && this.isBoardReady()) || force) {
         this.disconnecting = true;
         if (this.port === 'network') {
             this.board.sp.destroy();
         } else {
             if (this.board.sp && !this.board.sp.disconnected) {
-                if (!this.connecting) {
+                if (!this.connecting || force) {
                     // otherwise something went wrong in the middle of a connection attempt
                     this.board.sp.close();
                 } 
@@ -352,8 +352,8 @@ Arduino.prototype.connect = function (port, verify, channel) {
                         + port + '\n\n' + localize('Check if firmata is loaded.')
                         );
 
-                // silently closing the connection attempt
-                myself.disconnect(true); 
+                // silent and forced closing of the connection attempt
+                myself.disconnect(true, true);
             }
         }, 10000);
     };


### PR DESCRIPTION
Finally (:tada: ) fixing "noFirmata" attempts issue.

Current behavior:
- After a board connection but without a "good" firmata response, _sprite.arduino.board_ is created, but with an empty _sprite.arduino.board.pins_. Then _isBoardReady_ function return _false_ and so, _arduino.disconnect()_ does nothing.

- Also, _sprite.arduino.connecting_ is still _true_ and so, _disconnect()_ does not close its serial connection.

Solution:
A _forced disconnect_ operation to ensure _board_ is destroyed and the serial connection is disconnected when required. 