### PR TITLE
Fixing digital pins dropdown list

### DIFF
--- a/src/s4a/blocks.js
+++ b/src/s4a/blocks.js
@@ -32,7 +32,7 @@ SyntaxElementMorph.prototype.labelPart = function(spec) {
                     true
                     );
             break;
-        case '%servoPin':
+        case '%digitalPin':  // All digitals have modes INPUT, OUTPUT, SERVO AND PULLUP
             part = new InputSlotMorph(
                     null,
                     true,
@@ -42,7 +42,7 @@ SyntaxElementMorph.prototype.labelPart = function(spec) {
                             board = sprite.arduino.board;
 
                         if (board) {
-                            return sprite.arduino.pinsSettableToMode(board.MODES.SERVO);
+                            return sprite.arduino.pinsSettableToMode(board.MODES.INPUT);
                         } else {
                             return [];
                         }
@@ -86,37 +86,6 @@ SyntaxElementMorph.prototype.labelPart = function(spec) {
                         } else { 
                             return [];
                         } 
-                    }
-                    );
-            part.originalChanged = part.changed;
-            part.changed = function () { part.originalChanged(); if (block.toggle) { block.toggle.refresh(); } };
-            break;
-        case '%digitalPin':
-            part = new InputSlotMorph(
-                    null,
-                    true,
-                    function() {
-                        // Get board associated to currentSprite
-                        var sprite = ide.currentSprite,
-                            board = sprite.arduino.board;
-
-                        if (board) {
-                            var pinNumbers = [],
-                                pins = board.pins.filter(
-                                        function (each){ 
-                                            return each.analogChannel == 127 
-                                        });
-                            
-                            pins.forEach(
-                                    function (each) {
-                                        pinNumbers.push(pins.indexOf(each).toString());
-                                    });
-
-                            return pinNumbers;
-
-                        } else {
-                            return [];
-                        }
                     }
                     );
             part.originalChanged = part.changed;

--- a/src/s4a/lang-ca.js
+++ b/src/s4a/lang-ca.js
@@ -111,8 +111,8 @@ s4aTempDict = {
     'set digital pin %digitalPin to %b':
         'posa el pin digital %digitalPin a %b',
 
-    'set servo %servoPin to %servoValue':
-        'posa el servo %servoPin a %servoValue',
+    'set servo %digitalPin to %servoValue':
+        'posa el servo %digitalPin a %servoValue',
 
     'set pin %pwmPin to value %n':
         'posa el pin %pwmPin al valor %n',

--- a/src/s4a/lang-cs.js
+++ b/src/s4a/lang-cs.js
@@ -104,8 +104,8 @@ s4aTempDict = {
     'set digital pin %digitalPin to %b':
         'nastav digitální pin %digitalPin na %b',
 
-    'set servo %servoPin to %servoValue':
-        'nastav servo %servoPin na %servoValue',
+    'set servo %digitalPin to %servoValue':
+        'nastav servo %digitalPin na %servoValue',
 
     'set pin %pwmPin to value %n':
         'nastav PWM pin %pwmPin na %n',

--- a/src/s4a/lang-de.js
+++ b/src/s4a/lang-de.js
@@ -104,8 +104,8 @@ s4aTempDict = {
     'set digital pin %digitalPin to %b':
         'Setze digitalen Pin %digitalPin auf %b',
 
-    'set servo %servoPin to %servoValue':
-        'Setze Servo %servoPin auf %servoValue',
+    'set servo %digitalPin to %servoValue':
+        'Setze Servo %digitalPin auf %servoValue',
 
     'set pin %pwmPin to value %n':
         'Setze Pin %pwmPin auf %n',

--- a/src/s4a/lang-es.js
+++ b/src/s4a/lang-es.js
@@ -108,8 +108,8 @@ s4aTempDict = {
     'set digital pin %digitalPin to %b':
         'fijar pin digital %digitalPin en %b',
 
-    'set servo %servoPin to %servoValue':
-        'fijar servo %servoPin en %servoValue',
+    'set servo %digitalPin to %servoValue':
+        'fijar servo %digitalPin en %servoValue',
 
     'set pin %pwmPin to value %n':
         'fijar pin %pwmPin al valor %n',

--- a/src/s4a/lang-et.js
+++ b/src/s4a/lang-et.js
@@ -109,8 +109,8 @@ s4aTempDict = {
     'set digital pin %digitalPin to %b':
         'määra digitaalviigule %digitalPin väärtus %b',
 
-    'set servo %servoPin to %servoValue':
-        'määra servoviigule %servoPin väärtus %servoValue',
+    'set servo %digitalPin to %servoValue':
+        'määra servoviigule %digitalPin väärtus %servoValue',
 
     'set pin %pwmPin to value %n':
         'määra viigule %pwmPin väärtus %n',

--- a/src/s4a/lang-fr.js
+++ b/src/s4a/lang-fr.js
@@ -117,8 +117,8 @@ s4aTempDict = {
     'set digital pin %digitalPin to %b':
         'mettre la pin num\u00E9rique %digitalPin \u00E0 %b',
 
-    'set servo %servoPin to %servoValue':
-        'mettre le servo %servoPin \u00E0 %servoValue',
+    'set servo %digitalPin to %servoValue':
+        'mettre le servo %digitalPin \u00E0 %servoValue',
 
     'set pin %pwmPin to value %n':
         'mettre la pin %pwmPin \u00E0 %n',

--- a/src/s4a/lang-gl.js
+++ b/src/s4a/lang-gl.js
@@ -94,8 +94,8 @@ s4aTempDict = {
     'set digital pin %digitalPin to %b':
         'fixar pin dixital %digitalPin en %b',
 
-    'set servo %servoPin to %servoValue':
-        'fixar servo %servoPin en %servoValue',
+    'set servo %digitalPin to %servoValue':
+        'fixar servo %digitalPin en %servoValue',
 
     'set pin %pwmPin to value %n':
         'fixar pin %pwmPin ao valor %n',

--- a/src/s4a/lang-he.js
+++ b/src/s4a/lang-he.js
@@ -67,7 +67,7 @@
     'setup digital pin %digitalPin as %pinMode':  '%pinMode -ב %digitalPin  רגל קבע',
     
     'set digital pin %digitalPin to %b':  '%b -ל %digitalPin דיגיטליית רגל שנה',
-    'set servo %servoPin to %servoValue': '%servoValue -ל %servoPin ברגל מנוע הבא',
+    'set servo %digitalPin to %servoValue': '%servoValue -ל %digitalPin ברגל מנוע הבא',
     'set pin %pwmPin to value %n': '%n -ל %pwmPin ברגל PWM קבע',
     'Connecting board at port\n':  'חבר לכניסה\n',
     'An Arduino board has been connected. Happy prototyping!': 'ארדוינו חובר  בהצלחה!',

--- a/src/s4a/lang-id.js
+++ b/src/s4a/lang-id.js
@@ -105,8 +105,8 @@ s4aTempDict = {
     'set digital pin %digitalPin to %b':
         'set pin digital %digitalPin menjadi %b',
 
-    'set servo %servoPin to %servoValue':
-        'set servo %servoPin menjadi %servoValue',
+    'set servo %digitalPin to %servoValue':
+        'set servo %digitalPin menjadi %servoValue',
 
     'set pin %pwmPin to value %n':
         'set pin %pwmPin menjadi bernilai %n',

--- a/src/s4a/lang-it.js
+++ b/src/s4a/lang-it.js
@@ -107,8 +107,8 @@ s4aTempDict = {
     'set digital pin %digitalPin to %b':
         'imposta il pin digitale %digitalPin a %b',
 
-    'set servo %servoPin to %servoValue':
-        'imposta servo %servoPin a %servoValue',
+    'set servo %digitalPin to %servoValue':
+        'imposta servo %digitalPin a %servoValue',
 
     'set pin %pwmPin to value %n':
         'imposta il pin %pwmPin a %n',

--- a/src/s4a/lang-ko.js
+++ b/src/s4a/lang-ko.js
@@ -111,8 +111,8 @@ s4aTempDict = {
     'set digital pin %digitalPin to %b':
         '디지털 핀 %digitalPin 을 %b 로 설정하기',
 
-    'set servo %servoPin to %servoValue':
-        '서보 핀 %servoPin 을 %servoValue 로 설정하기',
+    'set servo %digitalPin to %servoValue':
+        '서보 핀 %digitalPin 을 %servoValue 로 설정하기',
 
     'set pin %pwmPin to value %n':
         'PWM 핀 %pwmPin 을 %n 으로 설정하기',

--- a/src/s4a/lang-nl.js
+++ b/src/s4a/lang-nl.js
@@ -104,8 +104,8 @@ s4aTempDict = {
     'set digital pin %digitalPin to %b':
         'zet digitale pin %digitalPin op %b',
 
-    'set servo %servoPin to %servoValue':
-        'zet servo %servoPin op %servoValue',
+    'set servo %digitalPin to %servoValue':
+        'zet servo %digitalPin op %servoValue',
 
     'set pin %pwmPin to value %n':
         'zet pin %pwmPin op %n',

--- a/src/s4a/lang-pt.js
+++ b/src/s4a/lang-pt.js
@@ -108,8 +108,8 @@ s4aTempDict = {
     'set digital pin %digitalPin to %b':
         'coloca no pino digital %digitalPin o valor booleano %b',
 
-    'set servo %servoPin to %servoValue':
-        'coloca o servo %servoPin %servoValue',
+    'set servo %digitalPin to %servoValue':
+        'coloca o servo %digitalPin %servoValue',
 
     'set pin %pwmPin to value %n':
         'coloca no pino (PWM) %pwmPin o valor %n',

--- a/src/s4a/lang-pt_BR.js
+++ b/src/s4a/lang-pt_BR.js
@@ -122,8 +122,8 @@ s4aTempDict = {
     'set digital pin %digitalPin to %b':
         'coloque no pino digital %digitalPin o valor booleano %b',
 
-    'set servo %servoPin to %servoValue':
-        'posicione o servo %servoPin em %servoValue',
+    'set servo %digitalPin to %servoValue':
+        'posicione o servo %digitalPin em %servoValue',
 
     'set pin %pwmPin to value %n':
         'coloque no pino %pwmPin o valor %n',

--- a/src/s4a/lang-ru.js
+++ b/src/s4a/lang-ru.js
@@ -97,8 +97,8 @@ s4aTempDict = {
     'set digital pin %digitalPin to %b':
         'изменить статус цифрового разъема %digitalPin на %b',
 
-    'set servo %servoPin to %servoValue':
-        'изменить статус разъема серво %servoPin нa %servoValue',
+    'set servo %digitalPin to %servoValue':
+        'изменить статус разъема серво %digitalPin нa %servoValue',
 
     'set pin %pwmPin to value %n':
         'изменить статус разъема PWM %pwmPin на %n',

--- a/src/s4a/lang-sv.js
+++ b/src/s4a/lang-sv.js
@@ -119,8 +119,8 @@ s4aTempDict = {
     'set digital pin %digitalPin to %b':
         's\u00e4tt digital pin %digitalPin till %b',
 
-    'set servo %servoPin to %servoValue':
-        's\u00e4tt servo %servoPin till %servoValue',
+    'set servo %digitalPin to %servoValue':
+        's\u00e4tt servo %digitalPin till %servoValue',
 
     'set pin %pwmPin to value %n':
         's\u00e4tt pin %pwmPin till v\u00e4rde %n',

--- a/src/s4a/lang-template.js
+++ b/src/s4a/lang-template.js
@@ -109,7 +109,7 @@ s4aTempDict = {
     'set digital pin %digitalPin to %b':
         '',
 
-    'set servo %servoPin to %servoValue':
+    'set servo %digitalPin to %servoValue':
         '',
 
     'set pin %pwmPin to value %n':

--- a/src/s4a/lang-tr.js
+++ b/src/s4a/lang-tr.js
@@ -127,8 +127,8 @@ s4aTempDict = {
     'set digital pin %digitalPin to %b':
         'Sayısal pin D %digitalPin değerini %b yap',
 
-    'set servo %servoPin to %servoValue':
-        'Servo pin D %servoPin değerini %servoValue yap',
+    'set servo %digitalPin to %servoValue':
+        'Servo pin D %digitalPin değerini %servoValue yap',
 
     'set pin %pwmPin to value %n':
         'Sayısal pin D %pwmPin değerini %n yap',

--- a/src/s4a/lang-uk.js
+++ b/src/s4a/lang-uk.js
@@ -97,8 +97,8 @@ s4aTempDict = {
     'set digital pin %digitalPin to %b':
         'змінити статус цифрового роз\u2019єму %digitalPin на %b',
 
-    'set servo %servoPin to %servoValue':
-        'змінити статус роз\u2019єму серво %servoPin нa %servoValue',
+    'set servo %digitalPin to %servoValue':
+        'змінити статус роз\u2019єму серво %digitalPin нa %servoValue',
 
     'set pin %pwmPin to value %n':
         'змінити статус роз\u2019єму PWM %pwmPin на %n',

--- a/src/s4a/lang-zh_CN.js
+++ b/src/s4a/lang-zh_CN.js
@@ -108,8 +108,8 @@ s4aTempDict = {
     'set digital pin %digitalPin to %b':
         '数字脚 %digitalPin 设置成 %b',
 
-    'set servo %servoPin to %servoValue':
-        '%servoPin 脚的舵机设置成 %servoValue',
+    'set servo %digitalPin to %servoValue':
+        '%digitalPin 脚的舵机设置成 %servoValue',
 
     'set pin %pwmPin to value %n':
         '%pwmPin 脚的值设置成 %n',

--- a/src/s4a/lang-zh_TW.js
+++ b/src/s4a/lang-zh_TW.js
@@ -109,8 +109,8 @@ s4aTempDict = {
     'set digital pin %digitalPin to %b':
         '數位腳 %digitalPin 設定成 %b',
 
-    'set servo %servoPin to %servoValue':
-        '%servoPin 腳的伺服馬達設定成 %servoValue',
+    'set servo %digitalPin to %servoValue':
+        '%digitalPin 腳的伺服馬達設定成 %servoValue',
 
     'set pin %pwmPin to value %n':
         '%pwmPin 腳的值設定成 %n',

--- a/src/s4a/objects.js
+++ b/src/s4a/objects.js
@@ -73,7 +73,7 @@ SpriteMorph.prototype.initArduinoBlocks = function () {
         only: SpriteMorph,
         type: 'command',
         category: 'arduino',
-        spec: 'set servo %servoPin to %servoValue',
+        spec: 'set servo %digitalPin to %servoValue',
         defaults: [null, ['clockwise']],
         transpilable: true
     };


### PR DESCRIPTION
All board digital pins report are assigned (by firmata) in modes INPUT, OUTPUT, SERVO and PULLUP.

_%servoPin_ dropdown option was fine, showing all digital pins, but _%digitalPin_ was not fine.

This PR moves all cases to a %digitalPin dropdown, showing correctly all available digital pins.

_lang_ files are updated too.