### PR TITLE
Introduce public/private options to HTTP server features

### DIFF
--- a/src/s4a/gui.js
+++ b/src/s4a/gui.js
@@ -59,7 +59,13 @@ IDE_Morph.prototype.settingsMenu = function () {
                 'toggleServer',
                 this.isServerOn ? 'uncheck to stop\nHTTP server' : 'check to start\nHTTP server, allowing\nremote control\nof Snap4Arduino'
         );
-
+        if (this.isServerOn) {
+            menu.addItem(
+                (this.isStagePublic ? '\u2611 ' : '\u2610 ') + localize('Public stage'),
+                'togglePublicStage',
+                this.isStagePublic ? 'uncheck to prevent the stage\nfrom being viewed\nfrom the HTTP server' : 'check to allow the stage\nto be viewed\nfrom the HTTP server'
+            );
+        }
         // network serial port option
         menu.addItem(
             (Arduino.prototype.networkPortsEnabled ? '\u2611 ' : '\u2610 ') + localize('Network serial ports'),

--- a/src/s4a/lang-ca.js
+++ b/src/s4a/lang-ca.js
@@ -196,7 +196,25 @@ s4aTempDict = {
         'Inicia Snap4Arduino en un\nmode de blocs amb icones\nper els/les programadors/es més joves',
 
     'Loading Snap Jr.':
-        'S\'està carregant Snap Júnior'
+        'S\'està carregant Snap Júnior',
+
+    'HTTP server':
+        'Servidor HTTP',
+
+    'uncheck to stop\nHTTP server':
+        'desmarqueu per aturar\nel servidor HTTP',
+
+    'check to start\nHTTP server, allowing\nremote control\nof Snap4Arduino':
+        'marqueu per iniciar\nel servidor HTTP, permetent\nel control remot\nde Snap4Arduino',
+
+    'Public stage':
+        'Escenari públic',
+
+    'uncheck to prevent the stage\nfrom being viewed\nfrom the HTTP server':
+        'desmarqueu per evitar que l\'escenari\nes vegi des del servidor HTTP',
+
+    'check to allow the stage\nto be viewed\nfrom the HTTP server':
+        'marqueu per permetre que l\'escenari\nes vegi des del servidor HTTP'
 
 };
 

--- a/src/s4a/lang-es.js
+++ b/src/s4a/lang-es.js
@@ -187,7 +187,25 @@ s4aTempDict = {
         'Repositorio de Snap4Arduino',
 
     'Start a Snap Jr. session':
-        'Inicia una sesión de Snap Junior'
+        'Inicia una sesión de Snap Junior',
+
+    'HTTP server':
+        'Servidor HTTP',
+
+    'uncheck to stop\nHTTP server':
+        'desmarcar para detener\nel servidor HTTP',
+
+    'check to start\nHTTP server, allowing\nremote control\nof Snap4Arduino':
+        'marcar para iniciar\nel servidor HTTP, habilitando\nel control remoto\nde Snap4Arduino',
+
+    'Public stage':
+        'Escenario público',
+
+    'uncheck to prevent the stage\nfrom being viewed\nfrom the HTTP server':
+        'desmarcar para evitar que el escenario\nse visualice desde el servidor HTTP',
+
+    'check to allow the stage\nto be viewed\nfrom the HTTP server':
+        'marcar para permitir que el escenario\nse visualice desde el servidor HTTP'
 };
 
 // Add attributes to original SnapTranslator.dict.es


### PR DESCRIPTION
Introduce public/private options (the same of S4A) to the HTTP server operation.

- Only messages starting with `+` are considered
- Only variables starting with `+` can be updated
- Only variables starting with `+` or `-` can be viewed
- A new `Public Stage` option is added to allow/prevent the stage display
