### PR TITLE
Added SoundScope website URLs to manifest.json in chromium extension

### DIFF
--- a/src/platforms/web/chromium/crx/manifest.json
+++ b/src/platforms/web/chromium/crx/manifest.json
@@ -22,7 +22,13 @@
             "http://snap4arduino.org/*",
             "http://snap4arduino.rocks/*",
             "https://snap4arduino.rocks/*"
-        ],
+            
+            "https://soundscope-website.web.app/*",
+            "http://soundscope-website.web.app/*",
+            "https://www.maketolearn.org/*",
+            "http://www.maketolearn.org/*",
+            "https://soundscope-website-beta.s3.amazonaws.com/*"
+	],
         "accepts_tls_channel_id": false
     },
     "icons": { "16": "icon-16.png", "128": "icon-128.png" },


### PR DESCRIPTION
Hello. I am a research assistant at the University of Virginia who is working on SoundScope (https://soundscope-website.web.app/), an online learning environment in which users can synthesize music using block coding via Snap! To further augment this environment, we would like for users to be able to connect to their Arduino boards and program unique playback effects (such as lights turning on/off in sync with the music that is currently playing and being displayed on a graph). We are also considering training a machine learning model to offer suggestions to users using Snap4Arduino (similarly to how iSnap, https://github.com/thomaswp/iSnap, uses logging to obtain data and train a model to assist in block-coding). Thus, we would greatly appreciate it if you could accept these links into the whitelist of websites that can fully utilize Snap4Arduino. If you would like more information about our use case, I would be delighted to provide it. Thank you for your consideration.